### PR TITLE
Fix password and hostname for sql conatiner

### DIFF
--- a/Beam.Server/appsettings.json
+++ b/Beam.Server/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=localhost;Initial Catalog=Beam;Integrated Security=False;User ID=sa;Password=@#^fcIen&*asd"
+    "DefaultConnection": "Data Source=blazor-get-started-2833058_devcontainer_sql_1;Initial Catalog=Beam;Integrated Security=False;User ID=sa;Password=@#^!fcIen&*asd"
   }
 }


### PR DESCRIPTION
Hostname and Password do not match and are incorrect for VSCode Docker Dev Containers. 

This causes an issue with connecting to the SQL server outside of the dev workspace, and a more ideal fix would take that into account. 